### PR TITLE
DLS-7936: Add navigation for litres packed globally

### DIFF
--- a/.g8/checkboxPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/checkboxPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -344,7 +344,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(identifier).fold[Option[Set[$className$]]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get.head mustBe checkboxItem
@@ -366,7 +366,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(identifier).fold[Option[Set[$className$]]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get.head mustBe checkboxItem
@@ -391,7 +391,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[Set[$className$]]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className$.values.toSet
@@ -413,7 +413,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[Set[$className$]]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className$.values.toSet

--- a/.g8/completedSummaryPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/completedSummaryPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -14,7 +14,7 @@ class $className$ControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.$className$Controller.onPageLoad.url)
+        val request = FakeRequest(GET, routes.$className$Controller.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/.g8/contentPage/generated-test/controllers/$className$ControllerSpec.scala
+++ b/.g8/contentPage/generated-test/controllers/$className$ControllerSpec.scala
@@ -14,7 +14,7 @@ class $className$ControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.$className$Controller.onPageLoad.url)
+        val request = FakeRequest(GET, routes.$className$Controller.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/.g8/datePage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/datePage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -324,7 +324,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date
@@ -346,7 +346,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date

--- a/.g8/multipleQuestionsPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/multipleQuestionsPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -262,7 +262,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[$className$]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff
@@ -282,7 +282,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[$className$]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff

--- a/.g8/radioButtonPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/radioButtonPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -233,7 +233,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(identifier).fold[Option[$className$]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio
@@ -255,7 +255,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[$className$]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio

--- a/.g8/stringPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/stringPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -214,7 +214,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[String]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff
@@ -234,7 +234,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[String]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff

--- a/.g8/textAreaPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/textAreaPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -214,7 +214,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[String]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff
@@ -234,7 +234,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[String]](None)(_.get($className$Page))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe $className;format="decap"$Diff

--- a/.g8/yesNoPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/yesNoPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -223,7 +223,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -244,7 +244,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected

--- a/.g8/yesNoWithDetailsPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/yesNoWithDetailsPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -226,7 +226,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -247,7 +247,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected

--- a/.g8/yesNoWithLitresAndDetailsPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/yesNoWithLitresAndDetailsPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -237,7 +237,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if(yesSelected) {
                   routes.HowMany$className$Controller.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
@@ -263,7 +263,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowMany$className$Controller.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))

--- a/.g8/yesNoWithLitresAndDetailsPage/generated-it-test/controllers/HowMany$className$ControllerISpec.scala
+++ b/.g8/yesNoWithLitresAndDetailsPage/generated-it-test/controllers/HowMany$className$ControllerISpec.scala
@@ -21,7 +21,7 @@ class HowMany$className$ControllerISpec extends LitresISpecHelper {
     val (path, redirectLocation) = if(mode == NormalMode) {
       (normalRoutePath, $nextPage$.url)
     } else {
-      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad.url)
+      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad().url)
     }
 
     "GET " + path - {

--- a/.g8/yesNoWithLitresPage/generated-it-test/controllers/$className$ControllerISpec.scala
+++ b/.g8/yesNoWithLitresPage/generated-it-test/controllers/$className$ControllerISpec.scala
@@ -237,7 +237,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if(yesSelected) {
                   routes.HowMany$className$Controller.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))
@@ -263,7 +263,7 @@ class $className$ControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowMany$className$Controller.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get($className$Page))

--- a/.g8/yesNoWithLitresPage/generated-it-test/controllers/HowMany$className$ControllerISpec.scala
+++ b/.g8/yesNoWithLitresPage/generated-it-test/controllers/HowMany$className$ControllerISpec.scala
@@ -21,7 +21,7 @@ class HowMany$className$ControllerISpec extends LitresISpecHelper {
     val (path, redirectLocation) = if(mode == NormalMode) {
       (normalRoutePath, $nextPage$.url)
     } else {
-      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad.url)
+      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad().url)
     }
 
     "GET " + path - {

--- a/app/controllers/ControllerHelper.scala
+++ b/app/controllers/ControllerHelper.scala
@@ -38,14 +38,14 @@ trait ControllerHelper extends FrontendBaseController with I18nSupport {
   private val internalServerErrorBaseMessage = "Failed to set value in session repository"
   private def sessionRepo500ErrorMessage(page: Page): String = s"$internalServerErrorBaseMessage while attempting set on ${page.toString}"
 
-  def updateDatabaseAndRedirect(updatedAnswers: Try[UserAnswers], page: Page, mode: Mode)
+  def updateDatabaseAndRedirect(updatedAnswers: Try[UserAnswers], page: Page, mode: Mode, previousAnswer: Option[String] = None)
                                (implicit ec: ExecutionContext, request: Request[AnyContent]): Future[Result] = {
     updatedAnswers match {
       case Failure(_) =>
         genericLogger.logger.error(s"Failed to resolve user answers while on ${page.toString}")
         Future.successful(InternalServerError(errorHandler.internalServerErrorTemplate))
       case Success(answers) => sessionService.set(answers).map {
-        case Right(_) => Redirect(navigator.nextPage(page, mode, answers))
+        case Right(_) => Redirect(navigator.nextPage(page, mode, answers, previousAnswer))
         case Left(_) =>
           genericLogger.logger.error(sessionRepo500ErrorMessage(page))
           InternalServerError(errorHandler.internalServerErrorTemplate)

--- a/app/controllers/HowManyLitresGloballyController.scala
+++ b/app/controllers/HowManyLitresGloballyController.scala
@@ -66,8 +66,9 @@ class HowManyLitresGloballyController @Inject()(
           Future.successful(BadRequest(view(formWithErrors, mode))),
 
         value => {
+          val previousValue = request.userAnswers.get(HowManyLitresGloballyPage).map(litres => litres.toString)
           val updatedAnswers = request.userAnswers.set(HowManyLitresGloballyPage, value)
-          updateDatabaseAndRedirect(updatedAnswers, HowManyLitresGloballyPage, mode)
+          updateDatabaseAndRedirect(updatedAnswers, HowManyLitresGloballyPage, mode, previousValue)
         }
       )
   }

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -23,7 +23,6 @@ import queries.{Gettable, Settable}
 import services.Encryption
 import uk.gov.hmrc.crypto.EncryptedValue
 import uk.gov.hmrc.crypto.json.CryptoFormats
-import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
 import java.time.Instant
 import scala.util.{Failure, Success, Try}

--- a/build.sbt
+++ b/build.sbt
@@ -8,9 +8,9 @@ lazy val appName: String = "soft-drinks-industry-levy-registration-frontend"
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .settings(inConfig(Test)(testSettings) *)
+  .settings(inConfig(Test)(testSettings): _*)
   .configs(IntegrationTest)
-  .settings(inConfig(IntegrationTest)(itSettings) *)
+  .settings(inConfig(IntegrationTest)(itSettings): _*)
   .settings(majorVersion := 0, libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always)
     // libraryDependencySchemes added to get around the scoverage compile errors for scala 2.13.10
   .settings(ThisBuild / useSuperShell := false)
@@ -55,7 +55,7 @@ lazy val root = (project in file("."))
           "javascripts/app.js"
         ))
     ),
-    //scalacOptions += "-deprecation",
+    scalacOptions += "-deprecation",
     scalacOptions ++= Seq("-Ypatmat-exhaust-depth", "off"),
     // prevent removal of unused code which generates warning errors due to use of third-party libs
     uglifyCompressOptions := Seq("unused=false", "dead_code=false"),

--- a/it/controllers/AskSecondaryWarehousesControllerISpec.scala
+++ b/it/controllers/AskSecondaryWarehousesControllerISpec.scala
@@ -146,7 +146,7 @@ class AskSecondaryWarehousesControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(AskSecondaryWarehousesPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -167,7 +167,7 @@ class AskSecondaryWarehousesControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(AskSecondaryWarehousesPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -225,7 +225,7 @@ class AskSecondaryWarehousesControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(AskSecondaryWarehousesPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -246,7 +246,7 @@ class AskSecondaryWarehousesControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(AskSecondaryWarehousesPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected

--- a/it/controllers/ContactDetailsControllerISpec.scala
+++ b/it/controllers/ContactDetailsControllerISpec.scala
@@ -148,7 +148,7 @@ class ContactDetailsControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[ContactDetails]](None)(_.get(ContactDetailsPage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe contactDetailsDiff
@@ -168,7 +168,7 @@ class ContactDetailsControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[ContactDetails]](None)(_.get(ContactDetailsPage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe contactDetailsDiff
@@ -262,7 +262,7 @@ class ContactDetailsControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[ContactDetails]](None)(_.get(ContactDetailsPage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe contactDetailsDiff
@@ -282,7 +282,7 @@ class ContactDetailsControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[ContactDetails]](None)(_.get(ContactDetailsPage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe contactDetailsDiff

--- a/it/controllers/ContractPackingControllerISpec.scala
+++ b/it/controllers/ContractPackingControllerISpec.scala
@@ -149,7 +149,7 @@ class ContractPackingControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyContractPackingController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ContractPackingPage))
@@ -175,7 +175,7 @@ class ContractPackingControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyContractPackingController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ContractPackingPage))
@@ -237,7 +237,7 @@ class ContractPackingControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if(yesSelected) {
                   routes.HowManyContractPackingController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ContractPackingPage))
@@ -263,7 +263,7 @@ class ContractPackingControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyContractPackingController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ContractPackingPage))

--- a/it/controllers/HowManyContractPackingControllerISpec.scala
+++ b/it/controllers/HowManyContractPackingControllerISpec.scala
@@ -19,9 +19,9 @@ class HowManyContractPackingControllerISpec extends LitresISpecHelper {
 
   List(NormalMode, CheckMode).foreach { mode =>
     val (path, redirectLocation) = if(mode == NormalMode) {
-      (normalRoutePath, routes.IndexController.onPageLoad.url)
+      (normalRoutePath, routes.IndexController.onPageLoad().url)
     } else {
-      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad.url)
+      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad().url)
     }
 
     "GET " + path - {

--- a/it/controllers/HowManyImportsControllerISpec.scala
+++ b/it/controllers/HowManyImportsControllerISpec.scala
@@ -19,9 +19,9 @@ class HowManyImportsControllerISpec extends LitresISpecHelper {
 
   List(NormalMode, CheckMode).foreach { mode =>
     val (path, redirectLocation) = if(mode == NormalMode) {
-      (normalRoutePath, routes.IndexController.onPageLoad.url)
+      (normalRoutePath, routes.IndexController.onPageLoad().url)
     } else {
-      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad.url)
+      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad().url)
     }
 
     "GET " + path - {

--- a/it/controllers/HowManyLitresGloballyControllerISpec.scala
+++ b/it/controllers/HowManyLitresGloballyControllerISpec.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import models.HowManyLitresGlobally
+import models.{CheckMode, HowManyLitresGlobally, NormalMode}
 import org.jsoup.Jsoup
 import org.scalatest.matchers.must.Matchers.{convertToAnyMustWrapper, include}
 import pages.HowManyLitresGloballyPage
@@ -139,9 +139,10 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
   }
 
   s"POST " + normalRoutePath - {
-    HowManyLitresGlobally.values.foreach { case radio =>
+    HowManyLitresGlobally.values.foreach {
+      case radio if radio == HowManyLitresGlobally.Large =>
       "when the user selects " + radio.toString - {
-        "should update the session with the new value and redirect to the index controller" - {
+        "should update the session with the new value and redirect to the operate packaging sites" - {
           "when the session contains no data for page" in {
             given
               .commonPrecondition
@@ -154,7 +155,7 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.OperatePackagingSitesController.onPageLoad(NormalMode).url)
                 val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio
@@ -176,7 +177,7 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.OperatePackagingSitesController.onPageLoad(NormalMode).url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio
@@ -185,6 +186,98 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
           }
         }
       }
+      case radio if radio == HowManyLitresGlobally.Small =>
+        "when the user selects " + radio.toString - {
+          "should update the session with the new value and redirect to the operate packaging sites" - {
+            "when the session contains no data for page" in {
+              given
+                .commonPrecondition
+
+              setAnswers(emptyUserAnswers)
+              WsTestClient.withClient { client =>
+                val result = createClientRequestPOST(
+                  client, baseUrl + normalRoutePath, Json.obj("value" -> radio)
+                )
+
+                whenReady(result) { res =>
+                  res.status mustBe 303
+                  res.header(HeaderNames.LOCATION) mustBe Some(routes.ThirdPartyPackagersController.onPageLoad(NormalMode).url)
+                  val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                  dataStoredForPage.nonEmpty mustBe true
+                  dataStoredForPage.get mustBe radio
+                }
+              }
+            }
+
+            "when the session already contains data for page" in {
+              given
+                .commonPrecondition
+
+              val userAnswers = emptyUserAnswers.set(HowManyLitresGloballyPage, radio).success.value
+
+              setAnswers(userAnswers)
+              WsTestClient.withClient { client =>
+                val result = createClientRequestPOST(
+                  client, baseUrl + normalRoutePath, Json.obj("value" -> radio)
+                )
+
+                whenReady(result) { res =>
+                  res.status mustBe 303
+                  res.header(HeaderNames.LOCATION) mustBe Some(routes.ThirdPartyPackagersController.onPageLoad(NormalMode).url)
+                  val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                  dataStoredForPage.nonEmpty mustBe true
+                  dataStoredForPage.get mustBe radio
+                }
+              }
+            }
+          }
+        }
+      case radio if radio == HowManyLitresGlobally.None =>
+        "when the user selects " + radio.toString - {
+          "should update the session with the new value and redirect to the operate packaging sites" - {
+            "when the session contains no data for page" in {
+              given
+                .commonPrecondition
+
+              setAnswers(emptyUserAnswers)
+              WsTestClient.withClient { client =>
+                val result = createClientRequestPOST(
+                  client, baseUrl + normalRoutePath, Json.obj("value" -> radio)
+                )
+
+                whenReady(result) { res =>
+                  res.status mustBe 303
+                  res.header(HeaderNames.LOCATION) mustBe Some(routes.ContractPackingController.onPageLoad(NormalMode).url)
+                  val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                  dataStoredForPage.nonEmpty mustBe true
+                  dataStoredForPage.get mustBe radio
+                }
+              }
+            }
+
+            "when the session already contains data for page" in {
+              given
+                .commonPrecondition
+
+              val userAnswers = emptyUserAnswers.set(HowManyLitresGloballyPage, radio).success.value
+
+              setAnswers(userAnswers)
+              WsTestClient.withClient { client =>
+                val result = createClientRequestPOST(
+                  client, baseUrl + normalRoutePath, Json.obj("value" -> radio)
+                )
+
+                whenReady(result) { res =>
+                  res.status mustBe 303
+                  res.header(HeaderNames.LOCATION) mustBe Some(routes.ContractPackingController.onPageLoad(NormalMode).url)
+                  val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                  dataStoredForPage.nonEmpty mustBe true
+                  dataStoredForPage.get mustBe radio
+                }
+              }
+            }
+          }
+        }
     }
 
     "when the user does not select an option" - {
@@ -217,8 +310,9 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
   }
 
   s"POST " + checkRoutePath - {
-    HowManyLitresGlobally.values.foreach { case radio =>
-      "when the user selects " + radio.toString - {
+    HowManyLitresGlobally.values.foreach {
+      case radio if radio == HowManyLitresGlobally.Large =>
+        "when the user selects " + radio.toString - {
         "should update the session with the new value and redirect to the checkAnswers controller" - {
           "when the session contains no data for page" in {
             given
@@ -232,7 +326,7 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.OperatePackagingSitesController.onPageLoad(CheckMode).url)
                 val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio
@@ -240,7 +334,7 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
             }
           }
 
-          "when the session already contains data for page" in {
+          "when the session already contains data for page and user clicks save and continue without changing the selection" in {
             given
               .commonPrecondition
 
@@ -254,7 +348,99 @@ class HowManyLitresGloballyControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
+                val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                dataStoredForPage.nonEmpty mustBe true
+                dataStoredForPage.get mustBe radio
+              }
+            }
+          }
+        }
+      }
+      case radio if radio == HowManyLitresGlobally.Small =>
+        "when the user selects " + radio.toString - {
+        "should update the session with the new value and redirect to the checkAnswers controller" - {
+          "when the session contains no data for page" in {
+            given
+              .commonPrecondition
+
+            setAnswers(emptyUserAnswers)
+            WsTestClient.withClient { client =>
+              val result = createClientRequestPOST(
+                client, baseUrl + checkRoutePath, Json.obj("value" -> Json.toJson(radio))
+              )
+
+              whenReady(result) { res =>
+                res.status mustBe 303
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.ThirdPartyPackagersController.onPageLoad(CheckMode).url)
+                val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                dataStoredForPage.nonEmpty mustBe true
+                dataStoredForPage.get mustBe radio
+              }
+            }
+          }
+
+          "when the session already contains data for page and user clicks save and continue without changing the selection" in {
+            given
+              .commonPrecondition
+
+            val userAnswers = emptyUserAnswers.set(HowManyLitresGloballyPage, radio).success.value
+
+            setAnswers(userAnswers)
+            WsTestClient.withClient { client =>
+              val result = createClientRequestPOST(
+                client, baseUrl + checkRoutePath, Json.obj("value" -> Json.toJson(radio))
+              )
+
+              whenReady(result) { res =>
+                res.status mustBe 303
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
+                val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                dataStoredForPage.nonEmpty mustBe true
+                dataStoredForPage.get mustBe radio
+              }
+            }
+          }
+        }
+      }
+      case radio if radio == HowManyLitresGlobally.None =>
+        "when the user selects " + radio.toString - {
+        "should update the session with the new value and redirect to the checkAnswers controller" - {
+          "when the session contains no data for page" in {
+            given
+              .commonPrecondition
+
+            setAnswers(emptyUserAnswers)
+            WsTestClient.withClient { client =>
+              val result = createClientRequestPOST(
+                client, baseUrl + checkRoutePath, Json.obj("value" -> Json.toJson(radio))
+              )
+
+              whenReady(result) { res =>
+                res.status mustBe 303
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.ContractPackingController.onPageLoad(CheckMode).url)
+                val dataStoredForPage = getAnswers(identifier).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
+                dataStoredForPage.nonEmpty mustBe true
+                dataStoredForPage.get mustBe radio
+              }
+            }
+          }
+
+          "when the session already contains data for page and user clicks save and continue without changing the selection" in {
+            given
+              .commonPrecondition
+
+            val userAnswers = emptyUserAnswers.set(HowManyLitresGloballyPage, radio).success.value
+
+            setAnswers(userAnswers)
+            WsTestClient.withClient { client =>
+              val result = createClientRequestPOST(
+                client, baseUrl + checkRoutePath, Json.obj("value" -> Json.toJson(radio))
+              )
+
+              whenReady(result) { res =>
+                res.status mustBe 303
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[HowManyLitresGlobally]](None)(_.get(HowManyLitresGloballyPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe radio

--- a/it/controllers/HowManyOperatePackagingSitesControllerISpec.scala
+++ b/it/controllers/HowManyOperatePackagingSitesControllerISpec.scala
@@ -19,9 +19,9 @@ class HowManyOperatePackagingSitesControllerISpec extends LitresISpecHelper {
 
   List(NormalMode, CheckMode).foreach { mode =>
     val (path, redirectLocation) = if(mode == NormalMode) {
-      (normalRoutePath, routes.IndexController.onPageLoad.url)
+      (normalRoutePath, routes.IndexController.onPageLoad().url)
     } else {
-      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad.url)
+      (checkRoutePath, routes.CheckYourAnswersController.onPageLoad().url)
     }
 
     "GET " + path - {

--- a/it/controllers/ImportsControllerISpec.scala
+++ b/it/controllers/ImportsControllerISpec.scala
@@ -149,7 +149,7 @@ class ImportsControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyImportsController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ImportsPage))
@@ -175,7 +175,7 @@ class ImportsControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyImportsController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ImportsPage))
@@ -237,7 +237,7 @@ class ImportsControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if(yesSelected) {
                   routes.HowManyImportsController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ImportsPage))
@@ -263,7 +263,7 @@ class ImportsControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyImportsController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ImportsPage))

--- a/it/controllers/OperatePackagingSitesControllerISpec.scala
+++ b/it/controllers/OperatePackagingSitesControllerISpec.scala
@@ -149,7 +149,7 @@ class OperatePackagingSitesControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyOperatePackagingSitesController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(OperatePackagingSitesPage))
@@ -175,7 +175,7 @@ class OperatePackagingSitesControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyOperatePackagingSitesController.onPageLoad(NormalMode).url
                 } else {
-                  routes.IndexController.onPageLoad.url
+                  routes.IndexController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(OperatePackagingSitesPage))
@@ -237,7 +237,7 @@ class OperatePackagingSitesControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if(yesSelected) {
                   routes.HowManyOperatePackagingSitesController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(OperatePackagingSitesPage))
@@ -263,7 +263,7 @@ class OperatePackagingSitesControllerISpec extends ControllerITTestHelper {
                 val expectedLocation = if (yesSelected) {
                   routes.HowManyOperatePackagingSitesController.onPageLoad(CheckMode).url
                 } else {
-                  routes.CheckYourAnswersController.onPageLoad.url
+                  routes.CheckYourAnswersController.onPageLoad().url
                 }
                 res.header(HeaderNames.LOCATION) mustBe Some(expectedLocation)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(OperatePackagingSitesPage))

--- a/it/controllers/PackagingSiteDetailsControllerISpec.scala
+++ b/it/controllers/PackagingSiteDetailsControllerISpec.scala
@@ -227,7 +227,7 @@ class PackagingSiteDetailsControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(PackagingSiteDetailsPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -248,7 +248,7 @@ class PackagingSiteDetailsControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(PackagingSiteDetailsPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -305,7 +305,7 @@ class PackagingSiteDetailsControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(PackagingSiteDetailsPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -326,7 +326,7 @@ class PackagingSiteDetailsControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(PackagingSiteDetailsPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected

--- a/it/controllers/RegistrationControllerISpec.scala
+++ b/it/controllers/RegistrationControllerISpec.scala
@@ -21,7 +21,7 @@ class RegistrationControllerISpec extends ControllerITTestHelper {
 
           whenReady(result1) { res =>
             res.status mustBe 303
-            res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+            res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
             getAnswers(identifier) mustBe defined
           }
         }

--- a/it/controllers/StartDateControllerISpec.scala
+++ b/it/controllers/StartDateControllerISpec.scala
@@ -149,7 +149,7 @@ class StartDateControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get(StartDatePage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date
@@ -171,7 +171,7 @@ class StartDateControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get(StartDatePage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date
@@ -321,7 +321,7 @@ class StartDateControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get(StartDatePage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date
@@ -343,7 +343,7 @@ class StartDateControllerISpec extends ControllerITTestHelper {
 
             whenReady(result) { res =>
               res.status mustBe 303
-              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+              res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
               val dataStoredForPage = getAnswers(identifier).fold[Option[LocalDate]](None)(_.get(StartDatePage))
               dataStoredForPage.nonEmpty mustBe true
               dataStoredForPage.get mustBe date

--- a/it/controllers/ThirdPartyPackagersControllerISpec.scala
+++ b/it/controllers/ThirdPartyPackagersControllerISpec.scala
@@ -144,7 +144,7 @@ class ThirdPartyPackagersControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ThirdPartyPackagersPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -165,7 +165,7 @@ class ThirdPartyPackagersControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.IndexController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ThirdPartyPackagersPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -222,7 +222,7 @@ class ThirdPartyPackagersControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ThirdPartyPackagersPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected
@@ -243,7 +243,7 @@ class ThirdPartyPackagersControllerISpec extends ControllerITTestHelper {
 
               whenReady(result) { res =>
                 res.status mustBe 303
-                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad.url)
+                res.header(HeaderNames.LOCATION) mustBe Some(routes.CheckYourAnswersController.onPageLoad().url)
                 val dataStoredForPage = getAnswers(userAnswers.id).fold[Option[Boolean]](None)(_.get(ThirdPartyPackagersPage))
                 dataStoredForPage.nonEmpty mustBe true
                 dataStoredForPage.get mustBe yesSelected

--- a/it/controllers/addressLookupFrontend/RampOffControllerISpec.scala
+++ b/it/controllers/addressLookupFrontend/RampOffControllerISpec.scala
@@ -35,7 +35,7 @@ class RampOffControllerISpec extends ControllerITTestHelper {
             updatedUserAnswers.warehouseList mustBe Map(sdilId -> Warehouse(Some("soft drinks ltd"), UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId))))
 
             res.status mustBe SEE_OTHER
-            res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.IndexController.onPageLoad.url)
+            res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.IndexController.onPageLoad().url)
           }
 
         }
@@ -62,7 +62,7 @@ class RampOffControllerISpec extends ControllerITTestHelper {
             updatedUserAnswers.warehouseList mustBe Map(sdilId -> Warehouse(Some("soft drinks ltd"), UkAddress(List("line 1", "line 2", "line 3", "line 4"), "aa1 1aa", alfId = Some(alfId))))
 
             res.status mustBe SEE_OTHER
-            res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.IndexController.onPageLoad.url)
+            res.header(HeaderNames.LOCATION) mustBe Some(controllers.routes.IndexController.onPageLoad().url)
           }
         }
       }

--- a/test/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/controllers/CheckYourAnswersControllerSpec.scala
@@ -31,7 +31,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
 
         val result = route(application, request).value
 
@@ -48,7 +48,7 @@ class CheckYourAnswersControllerSpec extends SpecBase with SummaryListFluency {
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.CheckYourAnswersController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/DoNotRegisterControllerSpec.scala
+++ b/test/controllers/DoNotRegisterControllerSpec.scala
@@ -30,7 +30,7 @@ class DoNotRegisterControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.DoNotRegisterController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.DoNotRegisterController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/IndexControllerSpec.scala
+++ b/test/controllers/IndexControllerSpec.scala
@@ -30,7 +30,7 @@ class IndexControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.IndexController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.IndexController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/RegistrationControllerSpec.scala
+++ b/test/controllers/RegistrationControllerSpec.scala
@@ -58,7 +58,7 @@ class RegistrationControllerSpec extends SpecBase with SummaryListFluency with M
             val result = route(application, request).value
 
             status(result) mustEqual SEE_OTHER
-            redirectLocation(result) mustEqual Some(routes.IndexController.onPageLoad.url)
+            redirectLocation(result) mustEqual Some(routes.IndexController.onPageLoad().url)
           }
         }
       }

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -30,7 +30,7 @@ class UnauthorisedControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -94,7 +94,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -112,7 +112,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -130,7 +130,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad.url
+          redirectLocation(result).value mustBe routes.UnauthorisedController.onPageLoad().url
         }
       }
     }
@@ -148,7 +148,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
         }
       }
     }
@@ -166,7 +166,7 @@ class AuthActionSpec extends SpecBase {
           val result = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
+          redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
         }
       }
     }

--- a/test/controllers/addressLookupFrontend/RampOffControllerSpec.scala
+++ b/test/controllers/addressLookupFrontend/RampOffControllerSpec.scala
@@ -82,7 +82,7 @@ class RampOffControllerSpec extends SpecBase with MockitoSugar {
 
         val result = route(app, request).value
         status(result) mustBe SEE_OTHER
-        redirectLocation(result).get mustBe controllers.routes.IndexController.onPageLoad.url
+        redirectLocation(result).get mustBe controllers.routes.IndexController.onPageLoad().url
       }
     }
     s"should return exception to the next page when ALF doesnt return Address successfully" in new Setup {

--- a/test/controllers/auth/AuthControllerSpec.scala
+++ b/test/controllers/auth/AuthControllerSpec.scala
@@ -79,7 +79,7 @@ class AuthControllerSpec extends SpecBase with MockitoSugar {
 
         val result = route(application, request).value
 
-        val encodedContinueUrl  = URLEncoder.encode(routes.SignedOutController.onPageLoad.url, "UTF-8")
+        val encodedContinueUrl  = URLEncoder.encode(routes.SignedOutController.onPageLoad().url, "UTF-8")
         val expectedRedirectUrl = s"${appConfig.signOutUrl}?continue=$encodedContinueUrl"
 
         status(result) mustEqual SEE_OTHER

--- a/test/controllers/auth/SignedOutControllerSpec.scala
+++ b/test/controllers/auth/SignedOutControllerSpec.scala
@@ -30,7 +30,7 @@ class SignedOutControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = None).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.SignedOutController.onPageLoad.url)
+        val request = FakeRequest(GET, routes.SignedOutController.onPageLoad().url)
 
         val result = route(application, request).value
 

--- a/test/navigation/FakeNavigator.scala
+++ b/test/navigation/FakeNavigator.scala
@@ -22,6 +22,6 @@ import models.{Mode, UserAnswers}
 
 class FakeNavigator(desiredRoute: Call) extends Navigator {
 
-  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers): Call =
+  override def nextPage(page: Page, mode: Mode, userAnswers: UserAnswers, previousAnswer: Option[String] = None): Call =
     desiredRoute
 }

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -18,6 +18,7 @@ package navigation
 
 import base.SpecBase
 import controllers.routes
+import models.HowManyLitresGlobally.{Large, Small}
 import models.OrganisationType.{LimitedCompany, LimitedLiabilityPartnership, Partnership, SoleTrader, UnincorporatedBody}
 import pages._
 import models._
@@ -37,46 +38,65 @@ class NavigatorSpec extends SpecBase {
         navigator.nextPage(UnknownPage, NormalMode, UserAnswers("id")) mustBe routes.IndexController.onPageLoad
       }
 
-      "must navigate to cannot register partnership page when on organisation type page and partnership is selected" in {
-        val result = navigator.nextPage(OrganisationTypePage, NormalMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> Partnership.toString)))
-        result mustBe routes.CannotRegisterPartnershipController.onPageLoad
+      "when on organisation type page" - {
+        "must navigate to cannot register partnership page and partnership is selected" in {
+          val result = navigator.nextPage(OrganisationTypePage, NormalMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> Partnership.toString)))
+          result mustBe routes.CannotRegisterPartnershipController.onPageLoad
+        }
+
+        "must navigate to how many litres globally page and limited company is selected" in {
+          val result = navigator.nextPage(OrganisationTypePage, NormalMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedCompany.toString)))
+          result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
+        }
+
+        "must navigate to how many litres globally page and limited liability partnership is selected" in {
+          val result = navigator.nextPage(OrganisationTypePage, NormalMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedLiabilityPartnership.toString)))
+          result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
+        }
+
+        "must navigate to how many litres globally page and unincorporated body is selected" in {
+          val result = navigator.nextPage(OrganisationTypePage, NormalMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> UnincorporatedBody.toString)))
+          result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
+        }
+
+        "must navigate to how many litres globally page and sole trader is selected" in {
+          val result = navigator.nextPage(OrganisationTypePage, NormalMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> SoleTrader.toString)))
+          result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
+        }
+
       }
 
-      "must navigate to cannot register partnership page when on organisation type page in check mode" in {
-        val result = navigator.nextPage(OrganisationTypePage, CheckMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> Partnership.toString)))
-        result mustBe routes.CannotRegisterPartnershipController.onPageLoad
-      }
+      "when on how many litres globally page" - {
 
-      "must navigate to how many litres globally page when on organisation type page and limited company is selected" in {
-        val result = navigator.nextPage(OrganisationTypePage, NormalMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedCompany.toString)))
-        result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
-      }
+        "must navigate to third party packagers page when less than 1 million litres is selected" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, NormalMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> Large.toString)))
+          result mustBe routes.OperatePackagingSitesController.onPageLoad(NormalMode)
+        }
 
-      "must navigate to how many litres globally page when on organisation type page and limited liability partnership is selected" in {
-        val result = navigator.nextPage(OrganisationTypePage, NormalMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedLiabilityPartnership.toString)))
-        result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
-      }
+        "must navigate to third party packagers page when less than less than 1 million litres is selected" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, NormalMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> Small.toString)))
+          result mustBe routes.ThirdPartyPackagersController.onPageLoad(NormalMode)
+        }
 
-      "must navigate to how many litres globally page when on organisation type page and unincorporated body is selected" in {
-        val result = navigator.nextPage(OrganisationTypePage, NormalMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> UnincorporatedBody.toString)))
-        result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
-      }
+        "must navigate to third party packagers page when None is selected" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, NormalMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> HowManyLitresGlobally.None.toString)))
+          result mustBe routes.ContractPackingController.onPageLoad(NormalMode)
+        }
 
-      "must navigate to how many litres globally page when on organisation type page and sole trader is selected" in {
-        val result = navigator.nextPage(OrganisationTypePage, NormalMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> SoleTrader.toString)))
-        result mustBe routes.HowManyLitresGloballyController.onPageLoad(NormalMode)
-      }
+        "must navigate to index controller page when no answer available in user answers" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, NormalMode,
+            UserAnswers("id", Json.obj()))
+          result mustBe routes.IndexController.onPageLoad()
+        }
 
-      "must navigate to check your answers page when on organisation type page in check mode" in {
-        val result = navigator.nextPage(OrganisationTypePage, CheckMode,
-          UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedCompany.toString)))
-        result mustBe routes.CheckYourAnswersController.onPageLoad
       }
 
     }
@@ -87,6 +107,48 @@ class NavigatorSpec extends SpecBase {
 
         case object UnknownPage extends Page
         navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe routes.CheckYourAnswersController.onPageLoad
+      }
+
+      "when on organisation type page" - {
+
+        "must navigate to cannot register partnership page in check mode" in {
+          val result = navigator.nextPage(OrganisationTypePage, CheckMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> Partnership.toString)))
+          result mustBe routes.CannotRegisterPartnershipController.onPageLoad
+        }
+
+        "must navigate to check your answers page in check mode" in {
+          val result = navigator.nextPage(OrganisationTypePage, CheckMode,
+            UserAnswers("id", Json.obj(OrganisationTypePage.toString -> LimitedCompany.toString)))
+          result mustBe routes.CheckYourAnswersController.onPageLoad
+        }
+      }
+
+      "when on how many litres globally page" - {
+
+        "must navigate to third party packagers page when less than 1 million litres is selected in check mode" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, CheckMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> Large.toString)))
+          result mustBe routes.OperatePackagingSitesController.onPageLoad(CheckMode)
+        }
+
+        "must navigate to third party packagers page when less than less than 1 million litres is selected in check mode" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, CheckMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> Small.toString)))
+          result mustBe routes.ThirdPartyPackagersController.onPageLoad(CheckMode)
+        }
+
+        "must navigate to third party packagers page when None is selected in check mode" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, CheckMode,
+            UserAnswers("id", Json.obj(HowManyLitresGloballyPage.toString -> HowManyLitresGlobally.None.toString)))
+          result mustBe routes.ContractPackingController.onPageLoad(CheckMode)
+        }
+
+        "must navigate to index controller page when no answer available in user answers" in {
+          val result = navigator.nextPage(HowManyLitresGloballyPage, CheckMode,
+            UserAnswers("id", Json.obj()))
+          result mustBe routes.IndexController.onPageLoad()
+        }
       }
     }
   }

--- a/test/services/AddressLookupServiceSpec.scala
+++ b/test/services/AddressLookupServiceSpec.scala
@@ -291,7 +291,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
             timeoutUrl = controllers.auth.routes.AuthController.signOut.url,
             timeoutKeepAliveUrl = Some(routes.KeepAliveController.keepAlive.url)
           )),
-          serviceHref = Some(routes.IndexController.onPageLoad.url),
+          serviceHref = Some(routes.IndexController.onPageLoad().url),
           pageHeadingStyle = Some("govuk-heading-m")
         ),
         labels = Some(
@@ -350,7 +350,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
             timeoutUrl = controllers.auth.routes.AuthController.signOut.url,
             timeoutKeepAliveUrl = Some(routes.KeepAliveController.keepAlive.url)
           )),
-          serviceHref = Some(routes.IndexController.onPageLoad.url),
+          serviceHref = Some(routes.IndexController.onPageLoad().url),
           pageHeadingStyle = Some("govuk-heading-m")
         ),
         labels = Some(
@@ -421,7 +421,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
             timeoutUrl = controllers.auth.routes.AuthController.signOut.url,
             timeoutKeepAliveUrl = Some(routes.KeepAliveController.keepAlive.url)
           )),
-          serviceHref = Some(routes.IndexController.onPageLoad.url),
+          serviceHref = Some(routes.IndexController.onPageLoad().url),
           pageHeadingStyle = Some("govuk-heading-m")
         ),
         labels = Some(
@@ -479,7 +479,7 @@ class AddressLookupServiceSpec extends SpecBase with FutureAwaits with DefaultAw
             timeoutUrl = controllers.auth.routes.AuthController.signOut.url,
             timeoutKeepAliveUrl = Some(routes.KeepAliveController.keepAlive.url)
           )),
-          serviceHref = Some(routes.IndexController.onPageLoad.url),
+          serviceHref = Some(routes.IndexController.onPageLoad().url),
           pageHeadingStyle = Some("govuk-heading-m")
         ),
         labels = Some(

--- a/test/viewmodels/PackagingSiteDetailsSummarySpec.scala
+++ b/test/viewmodels/PackagingSiteDetailsSummarySpec.scala
@@ -109,11 +109,11 @@ class PackagingSiteDetailsSummarySpec extends SpecBase {
       val packagingSiteSummaryRowList = PackagingSiteDetailsSummary.row2(Map("ref1" -> site1, "ref2" -> site2))
       packagingSiteSummaryRowList.head.key.content.asHtml.toString() mustBe "trade2<br>foo2, bar2, wizz2"
       packagingSiteSummaryRowList.head.actions.toList.head.items.last.content.asHtml.toString() mustBe "Remove"
-      packagingSiteSummaryRowList.head.actions.toList.head.items.last.href mustBe controllers.routes.IndexController.onPageLoad.url
+      packagingSiteSummaryRowList.head.actions.toList.head.items.last.href mustBe controllers.routes.IndexController.onPageLoad().url
 
       packagingSiteSummaryRowList.last.key.content.asHtml.toString() mustBe "trade<br>foo, bar, wizz"
       packagingSiteSummaryRowList.last.actions.toList.head.items.last.content.asHtml.toString() mustBe "Remove"
-      packagingSiteSummaryRowList.last.actions.toList.head.items.last.href mustBe controllers.routes.IndexController.onPageLoad.url
+      packagingSiteSummaryRowList.last.actions.toList.head.items.last.href mustBe controllers.routes.IndexController.onPageLoad().url
     }
   }
 

--- a/test/views/DoNotRegisterViewSpec.scala
+++ b/test/views/DoNotRegisterViewSpec.scala
@@ -52,7 +52,7 @@ class DoNotRegisterViewSpec extends ViewSpecHelper {
       document.getElementsByTag(Selectors.li).get(5).text() mustEqual "date you know you are going to bring liable drinks into the UK"
 
       document.getElementsByClass(Selectors.body).get(1).text() mustEqual "If this is not right, you need to go back and check your answers"
-      document.getElementById("goBackCheckAnswers").attr("href") mustBe controllers.routes.IndexController.onPageLoad.url
+      document.getElementById("goBackCheckAnswers").attr("href") mustBe controllers.routes.IndexController.onPageLoad().url
       document.getElementById("goBackCheckAnswers").text() mustEqual "go back and check your answers"
     }
 

--- a/test/views/PackagingSiteDetailsViewSpec.scala
+++ b/test/views/PackagingSiteDetailsViewSpec.scala
@@ -123,7 +123,7 @@ class PackagingSiteDetailsViewSpec extends ViewSpecHelper {
               val action = summaryRow.getElementsByClass(Selectors.link)
               if(numberOfPackagingSites > 1) {
                 action.text() mustBe "Remove packaging site"
-                action.attr("href") mustBe routes.IndexController.onPageLoad.url
+                action.attr("href") mustBe routes.IndexController.onPageLoad().url
               } else {
                 action.size() mustEqual 0
               }


### PR DESCRIPTION
DLS-7936: Add basic CYA navigations

DLS-7936: separate normal route and check route navigation functions

DLS-7936: cater for checkroute sceanarios

DLS-7936: test passing for checkmode navigation

DLS-7936: refactor navigator

DLS-7936: resolve merge conflicts

DLS-7936: styling fixes

DLS-7936: styling fixes

DLS-7936: styling fixes