### PR TITLE
DLS-11546 Update SDIL registration connector header propagation and logging

### DIFF
--- a/app/connectors/SoftDrinksIndustryLevyConnector.scala
+++ b/app/connectors/SoftDrinksIndustryLevyConnector.scala
@@ -51,7 +51,7 @@ class SoftDrinksIndustryLevyConnector @Inject() (
 
   private val rawHttpReads = new RawHttpReads
 
-  private def outboundHeaderCarrier(hc: HeaderCarrier): HeaderCarrier =
+  private def outboundHeaderCarrier(hc: HeaderCarrier): HeaderCarrier                                    =
     HeaderCarrier(
       requestId = hc.requestId,
       sessionId = hc.sessionId
@@ -68,7 +68,10 @@ class SoftDrinksIndustryLevyConnector @Inject() (
       startTime.map(st => s"durationMs=${System.currentTimeMillis() - st}")
     ).flatten.mkString(" ")
 
-  private def executeGet[A](operation: String, path: String)(implicit hc: HeaderCarrier, rds: HttpReads[A]): Future[A] = {
+  private def executeGet[A](operation: String, path: String)(implicit
+    hc: HeaderCarrier,
+    rds: HttpReads[A]
+  ): Future[A] = {
     val urlString = s"$sdilUrl$path"
     val startTime = System.currentTimeMillis()
     logger.info(

--- a/app/connectors/SoftDrinksIndustryLevyConnector.scala
+++ b/app/connectors/SoftDrinksIndustryLevyConnector.scala
@@ -22,7 +22,7 @@ import errors.{NoROSMRegistration, UnexpectedResponseFromSDIL}
 import models._
 import models.backend.Subscription
 import play.api.http.Status._
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import repositories.{SDILSessionCache, SDILSessionKeys}
 import service.RegistrationResult
 import uk.gov.hmrc.http.HttpReads.Implicits._
@@ -32,6 +32,7 @@ import utilities.GenericLogger
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 class SoftDrinksIndustryLevyConnector @Inject() (
   val http: HttpClientV2,
@@ -42,7 +43,82 @@ class SoftDrinksIndustryLevyConnector @Inject() (
 
   lazy val sdilUrl: String = frontendAppConfig.sdilBaseUrl
 
-  private def getRosmRegistration(utr: String): String = s"$sdilUrl/rosm-registration/lookup/$utr"
+  private val logger = genericLogger.logger
+
+  private class RawHttpReads extends HttpReads[HttpResponse] {
+    override def read(method: String, url: String, response: HttpResponse): HttpResponse = response
+  }
+
+  private val rawHttpReads = new RawHttpReads
+
+  private def outboundHeaderCarrier(hc: HeaderCarrier): HeaderCarrier =
+    HeaderCarrier(
+      requestId = hc.requestId,
+      sessionId = hc.sessionId
+    )
+
+  private def sdilContext(
+    path: String,
+    status: Option[Int] = None,
+    startTime: Option[Long] = None
+  ): String =
+    Seq(
+      Some(s"path=$path"),
+      status.map(st => s"status=$st"),
+      startTime.map(st => s"durationMs=${System.currentTimeMillis() - st}")
+    ).flatten.mkString(" ")
+
+  private def executeGet[A](operation: String, path: String)(implicit hc: HeaderCarrier, rds: HttpReads[A]): Future[A] = {
+    val urlString = s"$sdilUrl$path"
+    val startTime = System.currentTimeMillis()
+    logger.info(
+      s"SDIL $operation request ${sdilContext(path, startTime = Some(startTime))}"
+    )
+    http
+      .get(url"$urlString")(using outboundHeaderCarrier(hc))
+      .execute[HttpResponse](using rawHttpReads, ec)
+      .map { response =>
+        logger.info(
+          s"SDIL $operation response ${sdilContext(path, status = Some(response.status), startTime = Some(startTime))}"
+        )
+        rds.read("GET", urlString, response)
+      }
+      .recoverWith { case NonFatal(e) =>
+        logger.error(
+          s"SDIL $operation failure ${sdilContext(path, startTime = Some(startTime))} error=${e.getMessage}",
+          e
+        )
+        Future.failed(e)
+      }
+  }
+
+  private def executePost[A](operation: String, path: String, body: JsValue)(implicit
+    hc: HeaderCarrier,
+    rds: HttpReads[A]
+  ): Future[A] = {
+    val urlString = s"$sdilUrl$path"
+    val startTime = System.currentTimeMillis()
+    logger.info(
+      s"SDIL $operation request ${sdilContext(path, startTime = Some(startTime))}"
+    )
+    http
+      .post(url"$urlString")(using outboundHeaderCarrier(hc))
+      .withBody(body)
+      .execute[HttpResponse](using rawHttpReads, ec)
+      .map { response =>
+        logger.info(
+          s"SDIL $operation response ${sdilContext(path, status = Some(response.status), startTime = Some(startTime))}"
+        )
+        rds.read("POST", urlString, response)
+      }
+      .recoverWith { case NonFatal(e) =>
+        logger.error(
+          s"SDIL $operation failure ${sdilContext(path, startTime = Some(startTime))} error=${e.getMessage}",
+          e
+        )
+        Future.failed(e)
+      }
+  }
 
   def retreiveRosmSubscription(utr: String, internalId: String)(implicit
     hc: HeaderCarrier
@@ -50,9 +126,10 @@ class SoftDrinksIndustryLevyConnector @Inject() (
     sdilSessionCache.fetchEntry[RosmWithUtr](internalId, SDILSessionKeys.ROSM_REGISTRATION).flatMap {
       case Some(rosmReg) if rosmReg.utr == utr => Future.successful(Right(rosmReg))
       case _                                   =>
-        http
-          .get(url"${getRosmRegistration(utr)}")
-          .execute[Option[RosmRegistration]]
+        executeGet[Option[RosmRegistration]](
+          operation = "retreiveRosmSubscription",
+          path = s"/rosm-registration/lookup/$utr"
+        )
           .flatMap {
             case Some(rosmReg) =>
               val rosmWithUtr = RosmWithUtr(
@@ -64,29 +141,25 @@ class SoftDrinksIndustryLevyConnector @Inject() (
               }
             case None          => Future.successful(Left(NoROSMRegistration))
           }
-          .recover { case _ =>
-            genericLogger.logger
-              .error(s"[SoftDrinksIndustryLevyConnector][retreiveRosmSubscription] - unexpected response for $utr")
+          .recover { case NonFatal(_) =>
             Left(UnexpectedResponseFromSDIL)
           }
     }
   }
-
-  private def getSubscriptionUrl(identifierValue: String, identifierType: String): String =
-    s"$sdilUrl/subscription/$identifierType/$identifierValue"
-
   def checkPendingQueue(utr: String)(implicit hc: HeaderCarrier): RegistrationResult[SubscriptionStatus] = EitherT {
-    val pendingQueueUrl = s"$sdilUrl/check-enrolment-status/$utr"
-    http
-      .get(url"$pendingQueueUrl")
-      .execute[HttpResponse]
+    val path = s"/check-enrolment-status/$utr"
+    executeGet[HttpResponse](
+      operation = "checkPendingQueue",
+      path = path
+    )(using hc, rawHttpReads)
       .map(_.status match {
         case OK        => Right(Registered)
         case ACCEPTED  => Right(Pending)
         case NOT_FOUND => Right(DoesNotExist)
         case status    =>
-          genericLogger.logger
-            .warn(s"Returned unexpected status $status for ${hc.requestId} when attempting to check pending queue")
+          logger.warn(
+            s"SDIL checkPendingQueue unexpected-response ${sdilContext(path, status = Some(status))}"
+          )
           Left(UnexpectedResponseFromSDIL)
       })
   }
@@ -97,9 +170,10 @@ class SoftDrinksIndustryLevyConnector @Inject() (
     sdilSessionCache.fetchEntry[OptRetrievedSubscription](internalId, SDILSessionKeys.SUBSCRIPTION).flatMap {
       case Some(optSubscription) => Future.successful(Right(optSubscription.optRetrievedSubscription))
       case None                  =>
-        http
-          .get(url"${getSubscriptionUrl(identifierValue: String, identifierType)}")
-          .execute[Option[RetrievedSubscription]]
+        executeGet[Option[RetrievedSubscription]](
+          operation = "retrieveSubscription",
+          path = s"/subscription/$identifierType/$identifierValue"
+        )
           .flatMap { optRetrievedSubscription =>
             sdilSessionCache
               .save(internalId, SDILSessionKeys.SUBSCRIPTION, OptRetrievedSubscription(optRetrievedSubscription))
@@ -107,10 +181,7 @@ class SoftDrinksIndustryLevyConnector @Inject() (
                 Right(optRetrievedSubscription)
               }
           }
-          .recover { case _ =>
-            genericLogger.logger.error(
-              s"[SoftDrinksIndustryLevyConnector][retrieveSubscription] - unexpected response for $identifierValue"
-            )
+          .recover { case NonFatal(_) =>
             Left(UnexpectedResponseFromSDIL)
           }
     }
@@ -119,30 +190,28 @@ class SoftDrinksIndustryLevyConnector @Inject() (
   def createSubscription(subscription: Subscription, safeId: String)(implicit
     hc: HeaderCarrier
   ): RegistrationResult[Unit] = EitherT {
-    val createUrl = s"$sdilUrl/subscription/utr/${subscription.utr}/$safeId"
-    http
-      .post(url"$createUrl")
-      .withBody(Json.toJson(subscription))
-      .execute[HttpResponse]
+    val path = s"/subscription/utr/${subscription.utr}/$safeId"
+    executePost[HttpResponse](
+      operation = "createSubscription",
+      path = path,
+      body = Json.toJson(subscription)
+    )(using hc, rawHttpReads)
       .map { resp =>
         resp.status match {
           case OK       => Right((): Unit)
           case CONFLICT =>
-            genericLogger.logger.warn(
-              s"[SoftDrinksIndustryLevyConnector][createSubscription] - CONFLICT returned for ${subscription.utr}"
+            logger.warn(
+              s"SDIL createSubscription conflict ${sdilContext(path, status = Some(resp.status))}"
             )
             Right((): Unit)
           case status   =>
-            genericLogger.logger.error(
-              s"[SoftDrinksIndustryLevyConnector][createSubscription] - unexpected response $status for ${subscription.utr}"
+            logger.error(
+              s"SDIL createSubscription unexpected-response ${sdilContext(path, status = Some(status))}"
             )
             Left(UnexpectedResponseFromSDIL)
         }
       }
-      .recover { case _ =>
-        genericLogger.logger.error(
-          s"[SoftDrinksIndustryLevyConnector][createSubscription] - unexpected response for ${subscription.utr}"
-        )
+      .recover { case NonFatal(_) =>
         Left(UnexpectedResponseFromSDIL)
       }
   }

--- a/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
+++ b/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
@@ -200,7 +200,9 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper with Regist
       when(requestBuilderExecute[HttpResponse]).thenReturn(Future.successful(HttpResponse(200, "")))
 
       Await.result(
-        softDrinksIndustryLevyConnector.createSubscription(subscriptionOnlyRequiredFields, "safeid")(using incomingHc).value,
+        softDrinksIndustryLevyConnector
+          .createSubscription(subscriptionOnlyRequiredFields, "safeid")(using incomingHc)
+          .value,
         1.seconds
       )
 

--- a/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
+++ b/test/connectors/SoftDrinksIndustryLevyConnectorSpec.scala
@@ -16,17 +16,22 @@
 
 package connectors
 
+import base.RegistrationSubscriptionHelper
 import errors.NoROSMRegistration
 import models.{OptRetrievedSubscription, RetrievedSubscription, RosmRegistration, RosmWithUtr}
+import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
-import play.api.libs.json.Json
+import org.mockito.Mockito.{clearInvocations, verify, when}
+import play.api.libs.json.{JsValue, Json}
 import repositories.{CacheMap, SDILSessionCache}
+import uk.gov.hmrc.http.{Authorization, HeaderCarrier, HttpResponse, RequestId, SessionId}
 import utilities.GenericLogger
 
-import scala.concurrent.Future
+import java.net.URL
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration.*
 
-class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
+class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper with RegistrationSubscriptionHelper {
 
   val (host, localPort) = ("host", "123")
 
@@ -39,6 +44,26 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
   )
 
   val identifierMap = Map("sdil" -> sdilNumber, "utr" -> utr)
+
+  private def correlationHeaderCarrier(requestIdValue: String, sessionIdValue: String): HeaderCarrier =
+    HeaderCarrier(
+      authorization = Some(Authorization("Bearer incoming-token")),
+      sessionId = Some(SessionId(sessionIdValue)),
+      requestId = Some(RequestId(requestIdValue)),
+      deviceID = Some("device-id-1"),
+      otherHeaders = Seq("X-Test-Header" -> "should-not-forward")
+    )
+
+  private def assertSanitisedCorrelationIds(outboundHc: HeaderCarrier, incomingHc: HeaderCarrier): Unit = {
+    outboundHc.requestId mustBe incomingHc.requestId
+    outboundHc.sessionId mustBe incomingHc.sessionId
+    outboundHc.authorization mustBe None
+    outboundHc.deviceID mustBe None
+    outboundHc.otherHeaders mustBe Seq.empty
+  }
+
+  private def jsonResponse(status: Int, json: JsValue): HttpResponse =
+    HttpResponse(status, Json.stringify(json))
 
   "SoftDrinksIndustryLevyConnector" - {
 
@@ -55,7 +80,7 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
     s"should call the backend and return NoRosmRegistration if no rosm for utr" in {
       when(mockSDILSessionCache.fetchEntry[RosmRegistration](any(), any())(using any()))
         .thenReturn(Future.successful(None))
-      when(requestBuilderExecute[Option[RosmRegistration]]).thenReturn(Future.successful(None))
+      when(requestBuilderExecute[HttpResponse]).thenReturn(Future.successful(HttpResponse(404, "")))
       val res = softDrinksIndustryLevyConnector.retreiveRosmSubscription("utr here", "foo")
       whenReady(res.value) { response =>
         response mustEqual Left(NoROSMRegistration)
@@ -66,8 +91,8 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
       "and return the rosm when one is returned" in {
         when(mockSDILSessionCache.fetchEntry[RosmRegistration](any(), any())(using any()))
           .thenReturn(Future.successful(None))
-        when(requestBuilderExecute[Option[RosmRegistration]])
-          .thenReturn(Future.successful(Some(rosmRegistration.rosmRegistration)))
+        when(requestBuilderExecute[HttpResponse])
+          .thenReturn(Future.successful(jsonResponse(200, Json.toJson(rosmRegistration.rosmRegistration))))
         when(mockSDILSessionCache.save[RosmRegistration](any, any, any)(using any()))
           .thenReturn(Future.successful(CacheMap("test", Map("ROSM_REGISTRATION" -> Json.toJson(rosmRegistration)))))
         val res = softDrinksIndustryLevyConnector.retreiveRosmSubscription(utr = utr, "foo")
@@ -109,8 +134,8 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
               "and return the subscription when one is returned" in {
                 when(mockSDILSessionCache.fetchEntry[OptRetrievedSubscription](any(), any())(using any()))
                   .thenReturn(Future.successful(None))
-                when(requestBuilderExecute[Option[RetrievedSubscription]])
-                  .thenReturn(Future.successful(Some(aSubscription)))
+                when(requestBuilderExecute[HttpResponse])
+                  .thenReturn(Future.successful(jsonResponse(200, Json.toJson(aSubscription))))
                 when(mockSDILSessionCache.save[OptRetrievedSubscription](any, any, any)(using any())).thenReturn(
                   Future.successful(
                     CacheMap("test", Map("SUBSCRIPTION" -> Json.toJson(OptRetrievedSubscription(Some(aSubscription)))))
@@ -125,7 +150,7 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
               "and return None when no subscription returned" in {
                 when(mockSDILSessionCache.fetchEntry[OptRetrievedSubscription](any(), any())(using any()))
                   .thenReturn(Future.successful(None))
-                when(requestBuilderExecute[Option[RetrievedSubscription]]).thenReturn(Future.successful(None))
+                when(requestBuilderExecute[HttpResponse]).thenReturn(Future.successful(HttpResponse(404, "")))
                 when(mockSDILSessionCache.save[OptRetrievedSubscription](any, any, any)(using any())).thenReturn(
                   Future.successful(
                     CacheMap("test", Map("SUBSCRIPTION" -> Json.toJson(OptRetrievedSubscription(None))))
@@ -141,6 +166,48 @@ class SoftDrinksIndustryLevyConnectorSpec extends HttpClientV2Helper {
           }
         }
       }
+    }
+
+    "preserve correlation ids and strip custom headers in outbound GET HeaderCarrier for retrieveSubscription" in {
+      val incomingHc = correlationHeaderCarrier("request-id-registration-get-1", "session-id-registration-get-1")
+      clearInvocations(mockHttp)
+
+      when(mockSDILSessionCache.fetchEntry[OptRetrievedSubscription](any(), any())(using any()))
+        .thenReturn(Future.successful(None))
+      when(requestBuilderExecute[HttpResponse])
+        .thenReturn(Future.successful(jsonResponse(200, Json.toJson(aSubscription))))
+      when(mockSDILSessionCache.save[OptRetrievedSubscription](any, any, any)(using any())).thenReturn(
+        Future.successful(
+          CacheMap("test", Map("SUBSCRIPTION" -> Json.toJson(OptRetrievedSubscription(Some(aSubscription)))))
+        )
+      )
+
+      Await.result(
+        softDrinksIndustryLevyConnector.retrieveSubscription(sdilNumber, "sdil", "id")(using incomingHc).value,
+        1.seconds
+      )
+
+      val hcCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+      verify(mockHttp).get(any[URL])(using hcCaptor.capture())
+
+      assertSanitisedCorrelationIds(hcCaptor.getValue, incomingHc)
+    }
+
+    "preserve correlation ids and strip custom headers in outbound POST HeaderCarrier for createSubscription" in {
+      val incomingHc = correlationHeaderCarrier("request-id-registration-post-1", "session-id-registration-post-1")
+      clearInvocations(mockHttp)
+
+      when(requestBuilderExecute[HttpResponse]).thenReturn(Future.successful(HttpResponse(200, "")))
+
+      Await.result(
+        softDrinksIndustryLevyConnector.createSubscription(subscriptionOnlyRequiredFields, "safeid")(using incomingHc).value,
+        1.seconds
+      )
+
+      val hcCaptor: ArgumentCaptor[HeaderCarrier] = ArgumentCaptor.forClass(classOf[HeaderCarrier])
+      verify(mockHttp).post(any[URL])(using hcCaptor.capture())
+
+      assertSanitisedCorrelationIds(hcCaptor.getValue, incomingHc)
     }
   }
 }


### PR DESCRIPTION

 Updated the registration-side SDIL calls so they only pass requestId and sessionId downstream, instead of forwarding the full incoming HeaderCarrier. That covers the ROSM lookup, pending-enrolment check, subscription lookup, and create-subscription call.